### PR TITLE
Configurable base version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,12 @@
 version: 2.1
 
 parameters:
+  base-version:
+    type: string
+    default: "2023.03"
   otp-version:
     type: string
-    default: "25.2.3"
+    default: "25.3"
 
 commands:
   update_docker:
@@ -16,7 +19,11 @@ commands:
   compile:
     steps:
       - checkout
-      - run: OTP_VERSION=<<pipeline.parameters.otp-version>> ./compile.sh
+      - run:
+          name: Compile Erlang/OTP
+          command: |
+            BASE_VERSION=<<pipeline.parameters.base-version>> \
+            OTP_VERSION=<<pipeline.parameters.otp-version>> ./compile.sh
       - persist_to_workspace:
           root: ~/project/
           paths: ["builds"]
@@ -55,7 +62,9 @@ jobs:
           command: docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASS}
       - run:
           name: Build multi-platform docker image
-          command: OTP_VERSION=<<pipeline.parameters.otp-version>> ./circleci-build.sh
+          command: |
+            BASE_VERSION=<<pipeline.parameters.base-version>> \
+            OTP_VERSION=<<pipeline.parameters.otp-version>> ./circleci-build.sh
 
 workflows:
   main:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
     libncurses5-dev \
     unixodbc-dev
 
-RUN --mount=type=bind,source=builds/erlang-$TARGETARCH.tar.gz,target=erlang-$TARGETARCH.tar.gz \
-    tar -xzf erlang-$TARGETARCH.tar.gz -C ~ && \
+RUN --mount=type=bind \
+    tar -xzf builds/erlang-$TARGETARCH.tar.gz -C ~ && \
     cd ~/erlang-src && \
     sudo make install && \
     cd && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM cimg/base:current
+ARG BASE_VERSION=current
+FROM cimg/base:$BASE_VERSION
 
 ARG OTP_VERSION
 ARG TARGETARCH

--- a/Dockerfile-compile
+++ b/Dockerfile-compile
@@ -1,4 +1,5 @@
-FROM cimg/base:current
+ARG BASE_VERSION=current
+FROM cimg/base:$BASE_VERSION
 
 ARG OTP_VERSION
 ARG TARGETARCH

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-export OTP_VERSION=${1:-25.2.3}
+export OTP_VERSION=${1:-25.3}
 
 ./compile.sh
-docker build --build-arg OTP_VERSION -t cimg-erlang:$OTP_VERSION .
+docker build --build-arg BASE_VERSION --build-arg OTP_VERSION \
+  -t cimg-erlang:$OTP_VERSION .

--- a/circleci-build.sh
+++ b/circleci-build.sh
@@ -7,5 +7,6 @@ if [ $CIRCLE_BRANCH == "master" ]; then
 fi
 
 docker buildx build --platform linux/amd64,linux/arm64 \
-  --build-arg OTP_VERSION -t mongooseim/cimg-erlang:$OTP_VERSION \
-  --progress=plain -f Dockerfile $PUSH .
+    --build-arg BASE_VERSION --build-arg OTP_VERSION \
+    -t mongooseim/cimg-erlang:$OTP_VERSION \
+    --progress=plain -f Dockerfile $PUSH .

--- a/compile.sh
+++ b/compile.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-docker build --progress=plain --build-arg OTP_VERSION -t cimg-erlang-builder -f Dockerfile-compile .
+docker build --progress=plain --build-arg BASE_VERSION --build-arg OTP_VERSION \
+    -t cimg-erlang-builder -f Dockerfile-compile .
 BUILDER=`docker create cimg-erlang-builder`
 docker cp $BUILDER:/home/circleci/builds .
 docker rm $BUILDER


### PR DESCRIPTION
Add the `base-version` pipeline parameter, which together with `otp-version` allows triggering a on CircleCI for the requested base image and OTP version.

The default base image version is frozen at `2023.03`. We can change it back to `current` if we end up updating it too often.
If we need to build a specific version, the build can be triggered manually, making it repeatable.