### PR TITLE
Disable provenance to make the docker manifest backwards-compatible

### DIFF
--- a/circleci-build.sh
+++ b/circleci-build.sh
@@ -9,4 +9,4 @@ fi
 docker buildx build --platform linux/amd64,linux/arm64 \
     --build-arg BASE_VERSION --build-arg OTP_VERSION \
     -t mongooseim/cimg-erlang:$OTP_VERSION \
-    --progress=plain -f Dockerfile $PUSH .
+    --progress=plain -f Dockerfile --provenance=false $PUSH .


### PR DESCRIPTION
By default buildx creates OCI manifests, which cause a bug when you try to:
- Inspect the docker manifest - even in the latest docker version
- Pull the docker image in older docker - reproduced in 17.x

See docker/buildx#1509 for details.

**All tests succeeded**, and I re-run the build command with SSH to force docker image push. I tested the image and the manifest now works with Docker 17.x (did not work before), and it is possible to do `docker manifest inspect` with a new Docker as well (did not work before).