### PR TITLE
Extend the repo scope to general-purpose Docker images with Erlang

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,33 @@ parameters:
     default: "current"
   otp-version:
     type: string
-    default: "27.0"
+    default: "27.1.2"
+
+references:
+  - &job
+    parameters:
+      base-image:
+        type: string
+        default: "cimg/base:<<pipeline.parameters.base-version>>"
+      otp-version:
+        type: string
+        default: <<pipeline.parameters.otp-version>>
+      resource-class:
+        type: string
+        default: "medium"
+    machine:
+      image: ubuntu-2204:current
+    resource_class: <<parameters.resource-class>>
+  - &compile-amd64
+    name: compile-amd64
+  - &compile-arm64
+    name: compile-arm64
+    resource-class: "arm.medium"
+  - &build
+    context: mongooseim-org
+    requires:
+      - compile-amd64
+      - compile-arm64
 
 commands:
   update_docker:
@@ -17,37 +43,24 @@ commands:
           command: |
             sudo apt-get update
             sudo apt-get --only-upgrade install docker-ce docker-ce-cli containerd.io
+
+jobs:
   compile:
+    <<: *job
     steps:
+      - update_docker
       - checkout
       - run:
           name: Compile Erlang/OTP
           command: |
-            BASE_VERSION=<<pipeline.parameters.base-version>> \
-            OTP_VERSION=<<pipeline.parameters.otp-version>> ./compile.sh
+            BASE_IMAGE=<<parameters.base-image>> \
+            OTP_VERSION=<<parameters.otp-version>> \
+            PROGRESS=plain ./compile.sh
       - persist_to_workspace:
           root: ~/project/
           paths: ["builds"]
-
-jobs:
-  compile-amd64:
-    machine:
-      image: ubuntu-2204:current
-    resource_class: medium
-    steps:
-      - update_docker
-      - compile
-  compile-arm64:
-    machine:
-      image: ubuntu-2204:current
-    resource_class: arm.medium
-    steps:
-      - update_docker
-      - compile
   build:
-    machine:
-      image: ubuntu-2204:current
-    resource_class: medium
+    <<: *job
     steps:
       - update_docker
       - checkout
@@ -64,16 +77,133 @@ jobs:
       - run:
           name: Build multi-platform docker image
           command: |
-            BASE_VERSION=<<pipeline.parameters.base-version>> \
-            OTP_VERSION=<<pipeline.parameters.otp-version>> ./circleci-build.sh
+            BASE_IMAGE=<<parameters.base-image>> \
+            OTP_VERSION=<<parameters.otp-version>> ./circleci-build.sh
 
 workflows:
-  main:
+  cimg:
     jobs:
-      - compile-amd64
-      - compile-arm64
+      - compile: *compile-amd64
+      - compile: *compile-arm64
+      - build: *build
+  debian-bookworm:
+    jobs:
+      - compile:
+          <<: *compile-amd64
+          base-image: "debian:bookworm"
+      - compile:
+          <<: *compile-arm64
+          base-image: "debian:bookworm"
       - build:
-          context: mongooseim-org
-          requires:
-            - compile-amd64
-            - compile-arm64
+          <<: *build
+          base-image: "debian:bookworm"
+  debian-bullseye:
+    jobs:
+      - compile:
+          <<: *compile-amd64
+          base-image: "debian:bullseye"
+      - compile:
+          <<: *compile-arm64
+          base-image: "debian:bullseye"
+      - build:
+          <<: *build
+          base-image: "debian:bullseye"
+  debian-buster:
+    jobs:
+      - compile:
+          <<: *compile-amd64
+          base-image: "debian:buster"
+      - compile:
+          <<: *compile-arm64
+          base-image: "debian:buster"
+      - build:
+          <<: *build
+          base-image: "debian:buster"
+  ubuntu-oracular:
+    jobs:
+      - compile:
+          <<: *compile-amd64
+          base-image: "ubuntu:oracular"
+      - compile:
+          <<: *compile-arm64
+          base-image: "ubuntu:oracular"
+      - build:
+          <<: *build
+          base-image: "ubuntu:oracular"
+  ubuntu-noble:
+    jobs:
+      - compile:
+          <<: *compile-amd64
+          base-image: "ubuntu:noble"
+      - compile:
+          <<: *compile-arm64
+          base-image: "ubuntu:noble"
+      - build:
+          <<: *build
+          base-image: "ubuntu:noble"
+  ubuntu-jammy:
+    jobs:
+      - compile:
+          <<: *compile-amd64
+          base-image: "ubuntu:jammy"
+      - compile:
+          <<: *compile-arm64
+          base-image: "ubuntu:jammy"
+      - build:
+          <<: *build
+          base-image: "ubuntu:jammy"
+  ubuntu-focal:
+    jobs:
+      - compile:
+          <<: *compile-amd64
+          base-image: "ubuntu:focal"
+      - compile:
+          <<: *compile-arm64
+          base-image: "ubuntu:focal"
+      - build:
+          <<: *build
+          base-image: "ubuntu:focal"
+  rockylinux-9:
+    jobs:
+      - compile:
+          <<: *compile-amd64
+          base-image: "rockylinux:9"
+      - compile:
+          <<: *compile-arm64
+          base-image: "rockylinux:9"
+      - build:
+          <<: *build
+          base-image: "rockylinux:9"
+  rockylinux-8:
+    jobs:
+      - compile:
+          <<: *compile-amd64
+          base-image: "rockylinux:8"
+      - compile:
+          <<: *compile-arm64
+          base-image: "rockylinux:8"
+      - build:
+          <<: *build
+          base-image: "rockylinux:8"
+  almalinux-9:
+    jobs:
+      - compile:
+          <<: *compile-amd64
+          base-image: "almalinux:9"
+      - compile:
+          <<: *compile-arm64
+          base-image: "almalinux:9"
+      - build:
+          <<: *build
+          base-image: "almalinux:9"
+  almalinux-8:
+    jobs:
+      - compile:
+          <<: *compile-amd64
+          base-image: "almalinux:8"
+      - compile:
+          <<: *compile-arm64
+          base-image: "almalinux:8"
+      - build:
+          <<: *build
+          base-image: "almalinux:8"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,23 @@
-ARG BASE_VERSION=current
-FROM cimg/base:$BASE_VERSION
+ARG BASE_IMAGE=cimg/base:current
+FROM $BASE_IMAGE
 
+ARG BASE_IMAGE
 ARG OTP_VERSION
 ARG TARGETARCH
+ARG USER=root
 ENV OTP_VERSION=$OTP_VERSION
 ENV ARCH=$TARGETARCH
 
-RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
-    libncurses5-dev \
-    unixodbc-dev
+USER root
 
-RUN --mount=type=bind \
-    tar -xzf builds/erlang-$TARGETARCH.tar.gz -C ~ && \
-    cd ~/erlang-src && \
-    sudo make install && \
+RUN --mount=type=bind,src=tools,dst=/tools \
+    /tools/prepare.sh build
+
+RUN --mount=type=bind,src=builds,dst=/builds \
+    tar -xzf /builds/erlang-$TARGETARCH.tar.gz -C / && \
+    cd /erlang-src && \
+    make install && \
     cd && \
-    rm -rf erlang-src
+    rm -rf /erlang-src
+
+USER $USER

--- a/Dockerfile-compile
+++ b/Dockerfile-compile
@@ -1,22 +1,23 @@
-ARG BASE_VERSION=current
-FROM cimg/base:$BASE_VERSION
+ARG BASE_IMAGE=cimg/base:current
+FROM $BASE_IMAGE
 
+ARG BASE_IMAGE
 ARG OTP_VERSION
 ARG TARGETARCH
+ARG SETUP
 
-RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
-    libncurses5-dev \
-    unixodbc-dev
+USER root
+
+RUN --mount=type=bind,src=tools,dst=/tools \
+    /tools/prepare.sh compile
 
 RUN ERLANG_DOWNLOAD_URL="https://github.com/erlang/otp/releases/download/OTP-$OTP_VERSION/otp_src_$OTP_VERSION.tar.gz" && \
-    cd && \
-    mkdir erlang-src && \
-    cd erlang-src && \
+    mkdir /erlang-src && \
+    cd /erlang-src && \
     curl -fSL -o erlang.tar.gz $ERLANG_DOWNLOAD_URL && \
     tar -xz --strip-components=1 -f erlang.tar.gz && \
     ./configure && \
     make
 
-RUN cd && \
-    mkdir builds && \
-    tar -czf builds/erlang-$TARGETARCH.tar.gz erlang-src
+RUN mkdir /builds && \
+    tar -czf /builds/erlang-$TARGETARCH.tar.gz /erlang-src

--- a/README.md
+++ b/README.md
@@ -1,17 +1,31 @@
 # cimg-erlang
-Docker images for CircleCI with Erlang/OTP.
 
-CircleCI provides only [cimg-elixir](https://circleci.com/docs/circleci-images/#elixir), which includes Erlang, but it is only for the `amd64` architecture, and Erlang versions are often not up to date.
+Multi-purpose Docker images with the [Erlang](https://www.erlang.org/) programming language installed. They are built on demand by Erlang Solutions.
 
-There are two ways to use an Erlang image:
-* Use [`mongooseim/cimg-erlang`](https://hub.docker.com/repository/docker/mongooseim/cimg-erlang) directly in a docker executor.
-* Build it for a specific version of Erlang on your own:
+They include:
+- CircleCI convenience images based on [cimg/base](https://circleci.com/developer/images/image/cimg/base) that can be used to execute CircleCI jobs. See [Convenience images](https://circleci.com/docs/circleci-images/) for details.
+- Ubuntu, Debian, Rocky Linux and AlmaLinux. These are used to build software packages, e.g. for [MongooseIM](https://github.com/esl/mongooseim).
+
+## Usage
+
+The simplest way is to use the images from the [`erlangsolutions/erlang`](https://hub.docker.com/repository/docker/erlangsolutions/erlang/general) repo.
+
+- CircleCI images are tagged as `cimg-${ERLANG_VERSION}`, e.g. `cimg-27.1.2`, and you can use them in the CircleCI docker executor.
+- Other images are tagged as `${OS}-${RELEASE}-${ERLANG_VERSION}`, e.g. `ubuntu-jammy-27.1.2`, and they can be used to build, package and run Erlang software.
+
+## Build procedure
+
+You can also clone the [esl/cimg-erlang](https://github.com/esl/cimg-erlang) repository, and build the Docker image yourself with `build.sh`:
 
 ```bash
-$ ./build.sh 25.2.3
+$ OTP_VERSION=27.1.2 BASE_IMAGE=ubuntu:jammy ./build.sh
 ```
 
-# Trigger build using "Trigger pipeline" on CircleCI
+Note that only selected Linux distributions are supported (see [`tools/prepare.sh`](https://github.com/esl/cimg-erlang/blob/master/tools/prepare.sh)).
+
+## Trigger build using "Trigger pipeline" on CircleCI
+
+If you are a member of Erlang Solutions, you can trigger a CI build.
 
 Go to the CircleCI project page, select branch: [CircleCI](https://app.circleci.com/pipelines/github/esl/cimg-erlang?branch=master).
 

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-export OTP_VERSION=${1:-25.3}
+source tools/utils.sh
 
 ./compile.sh
-docker build --build-arg BASE_VERSION --build-arg OTP_VERSION \
-  -t cimg-erlang:$OTP_VERSION .
+
+set_up_build
+
+docker build --build-arg BASE_IMAGE --build-arg OTP_VERSION --build-arg USER \
+    -t cimg-erlang:$IMAGE_TAG .

--- a/circleci-build.sh
+++ b/circleci-build.sh
@@ -6,7 +6,11 @@ if [ $CIRCLE_BRANCH == "master" ]; then
    PUSH="--push"
 fi
 
+source tools/utils.sh
+
+set_up_build
+
 docker buildx build --platform linux/amd64,linux/arm64 \
-    --build-arg BASE_VERSION --build-arg OTP_VERSION \
-    -t mongooseim/cimg-erlang:$OTP_VERSION \
+    --build-arg BASE_IMAGE --build-arg OTP_VERSION --build-arg USER \
+    -t erlangsolutions/erlang:$IMAGE_TAG \
     --progress=plain -f Dockerfile --provenance=false $PUSH .

--- a/compile.sh
+++ b/compile.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-docker build --progress=plain --build-arg BASE_VERSION --build-arg OTP_VERSION \
+docker build --progress=${PROGRESS:-auto} --build-arg BASE_IMAGE --build-arg OTP_VERSION \
     -t cimg-erlang-builder -f Dockerfile-compile .
 BUILDER=`docker create cimg-erlang-builder`
-docker cp $BUILDER:/home/circleci/builds .
+docker cp $BUILDER:builds .
 docker rm $BUILDER

--- a/tools/prepare.sh
+++ b/tools/prepare.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+prepare() {
+    EXTRA_PACKAGES=${1:-}
+    case $BASE_IMAGE in
+        ubuntu:* | debian:* | cimg/base:*)
+            apt-get update
+            apt-get install -y --no-install-recommends \
+                libncurses5-dev unixodbc-dev make gcc g++ curl ca-certificates libssl-dev \
+                $EXTRA_PACKAGES
+            ;;
+        rockylinux:8 | almalinux:8)
+            dnf update -y
+            dnf install -y unixODBC-devel make gcc gcc-c++ openssl openssl-devel ncurses-devel \
+                $EXTRA_PACKAGES
+            ;;
+        rockylinux:9 | almalinux:9)
+            dnf update -y
+            dnf install -y 'dnf-command(config-manager)'
+            dnf config-manager --set-enabled crb
+            dnf install -y unixODBC-devel make gcc gcc-c++ openssl openssl-devel ncurses-devel \
+                $EXTRA_PACKAGES
+            ;;
+        *)
+            echo "Uknown base image: $BASE_IMAGE"
+            exit 1
+            ;;
+    esac
+}
+
+case ${1:-} in
+    "compile")
+        prepare "perl"
+        ;;
+    "build")
+        prepare
+        ;;
+    "")
+        echo "Missing command"
+        exit 2
+        ;;
+    *)
+        echo "Unknown command: $1"
+        exit 3
+        ;;
+esac

--- a/tools/utils.sh
+++ b/tools/utils.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set_up_build() {
+    BASE_IMAGE=${BASE_IMAGE:-cimg/base:current}
+    BASE_IMAGE_NAME=${BASE_IMAGE%:*}
+    BASE_IMAGE_VERSION=${BASE_IMAGE#*:}
+
+    if [ "${BASE_IMAGE%:*}" = "cimg/base" ]; then
+        USER=circleci # CircleCI convenience images require a special user
+        IMAGE_TAG=cimg-${OTP_VERSION}
+    else
+        USER=root
+        IMAGE_TAG=${BASE_IMAGE_NAME}-${BASE_IMAGE_VERSION}-${OTP_VERSION}
+    fi
+}


### PR DESCRIPTION
The goal is to extend this repo to build not only `cimg` images for CircleCI executors, but also general purpose images with Erlang. The current purpose of these extra images will be building packages with MongooseIM.

Main changes:
- Support multiple base images. Currently, these are: 
  - debian (bookworm, bullseye, buster),
  - ubuntu (oracular, noble, jammy, focal),
  - rockylinux (8, 9),
  - almalinux (8, 9).
- Extend the pipeline to contain one workflow per base image.
- Extend Dockerfiles and build scripts to share the common parts, and call utility scripts to perform steps which differ between the OS's.
- Document the new scope of this repo.
- Push images to [erlangsolutions/erlang](https://hub.docker.com/repository/docker/erlangsolutions/erlang/general). I made a modification to push all images - to check that it works. Images will be pushed again from `master` when this PR is merged.

The resulting images were tested, and they all can be successfully used to run MongooseIM CI (in case of `cimg`) or build the MongooseIM packages (all other images). See this [temporary CI build](https://app.circleci.com/pipelines/github/esl/MongooseIM/13093/workflows/7f81784d-edec-4982-90ad-12509359bc06).

Next steps:
- Finish and merge the PR to MongooseIM, which will build all packages using the images built here.
- Later: publish the new packages. We could do it with the next release.

Other future improvements - IMO not needed for now:
- Add smoke tests to this repo to make sure that the OS/release is correct, and that `erl` works and has the correct version. For now the MIM smoke test should be enough.
- Generate the OS/release list in `config.yml` automatically, and sync it with MIM package building config.