### PR TITLE
Add smoke test to check Erlang version and OS name/version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,7 @@ RUN --mount=type=bind,src=builds,dst=/builds \
     cd && \
     rm -rf /erlang-src
 
+RUN --mount=type=bind,src=tools,dst=/tools \
+    /tools/smoke_test.sh
+
 USER $USER

--- a/tools/smoke_test.sh
+++ b/tools/smoke_test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+compare() {
+    NAME=$1
+    EXPECTED_VALUE=$2
+    ACTUAL_VALUE=$3
+    if [ $ACTUAL_VALUE != $EXPECTED_VALUE ]; then
+        echo "Incorrect $NAME: $ACTUAL_VALUE instead of $EXPECTED_VALUE"
+        exit 1
+    else
+        echo "Correct $NAME: $ACTUAL_VALUE"
+    fi
+}
+
+check_erlang() {
+    ERL='io:format("~s~n", [filename:join([code:root_dir(), "releases",
+                                           erlang:system_info(otp_release), "OTP_VERSION"])]),
+         halt().'
+    OTP_VERSION_FILE=$(erl -eval "$ERL" -noinput)
+    compare "OTP version" "$OTP_VERSION" "$(<$OTP_VERSION_FILE)"
+}
+
+check_system_name() {
+    case $BASE_IMAGE in
+        cimg/base:*)
+            compare "OS name" "ubuntu" "$ID"
+            ;;
+        rockylinux:*)
+            compare "OS name" "rocky" "$ID"
+            ;;
+        *)
+            compare "OS name" "${BASE_IMAGE%:*}" "$ID"
+            ;;
+    esac
+}
+
+check_system_version() {
+    case $BASE_IMAGE in
+        cimg/base:*)
+            ;; # version might change, so it is not checked here
+        rockylinux:* | almalinux:*)
+            compare "OS version" "${BASE_IMAGE#*:}" "${VERSION%.*}"
+            ;;
+        *)
+            compare "OS version" "${BASE_IMAGE#*:}" "$VERSION_CODENAME"
+            ;;
+    esac
+}
+
+check_erlang
+source /etc/os-release
+check_system_name
+check_system_version


### PR DESCRIPTION
The main purpose is to verify that:
- Erlang is present with the correct version.
- OS name and release is correct. For `cimg/base`, version isn't checked, because we are using the `current` tag.

Example output from a successful job:
```
(...)
#14 2.121 Correct OTP version: 27.1.2
#14 2.129 Correct OS name: ubuntu
#14 2.130 Correct OS version: jammy
```
I also tested unsuccessful cases by modifying the OTP version manually.