### PR TITLE
Compile OpenSSL 3.x for older systems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,13 @@ USER root
 RUN --mount=type=bind,src=tools,dst=/tools \
     /tools/prepare.sh build
 
-RUN --mount=type=bind,src=builds,dst=/builds \
-    tar -xzf /builds/erlang-$TARGETARCH.tar.gz -C / && \
-    cd /erlang-src && \
-    make install && \
-    cd && \
-    rm -rf /erlang-src
+RUN --mount=type=bind,src=tools,dst=/tools \
+    --mount=type=bind,src=builds,dst=/builds \
+    /tools/openssl_setup.sh install
+
+RUN --mount=type=bind,src=tools,dst=/tools \
+    --mount=type=bind,src=builds,dst=/builds \
+    /tools/erlang_setup.sh install
 
 RUN --mount=type=bind,src=tools,dst=/tools \
     /tools/smoke_test.sh

--- a/Dockerfile-compile
+++ b/Dockerfile-compile
@@ -5,19 +5,15 @@ ARG BASE_IMAGE
 ARG OTP_VERSION
 ARG TARGETARCH
 ARG SETUP
+ARG OPENSSL_VERSION
 
 USER root
 
 RUN --mount=type=bind,src=tools,dst=/tools \
     /tools/prepare.sh compile
 
-RUN ERLANG_DOWNLOAD_URL="https://github.com/erlang/otp/releases/download/OTP-$OTP_VERSION/otp_src_$OTP_VERSION.tar.gz" && \
-    mkdir /erlang-src && \
-    cd /erlang-src && \
-    curl -fSL -o erlang.tar.gz $ERLANG_DOWNLOAD_URL && \
-    tar -xz --strip-components=1 -f erlang.tar.gz && \
-    ./configure && \
-    make
+RUN --mount=type=bind,src=tools,dst=/tools \
+    /tools/openssl_setup.sh compile
 
-RUN mkdir /builds && \
-    tar -czf /builds/erlang-$TARGETARCH.tar.gz /erlang-src
+RUN --mount=type=bind,src=tools,dst=/tools \
+    /tools/erlang_setup.sh compile

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ You can also clone the [esl/cimg-erlang](https://github.com/esl/cimg-erlang) rep
 ```bash
 $ OTP_VERSION=27.1.2 BASE_IMAGE=ubuntu:jammy ./build.sh
 ```
+Optionally, you can set the `OPENSSL_VERSION` argument (e.g., `3.0.16`) to choose which OpenSSL version should be compiled for use on older systems.
+This version is used specifically by Erlang and may differ from the system-wide OpenSSL version.
 
 Note that only selected Linux distributions are supported (see [`tools/prepare.sh`](https://github.com/esl/cimg-erlang/blob/master/tools/prepare.sh)).
-Optionally, you can set the `OPENSSL_VERSION` argument (e.g., `3.0.16`) to choose which OpenSSL version should be compiled for use on older systems.
 
 ## Trigger build using "Trigger pipeline" on CircleCI
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ $ OTP_VERSION=27.1.2 BASE_IMAGE=ubuntu:jammy ./build.sh
 ```
 
 Note that only selected Linux distributions are supported (see [`tools/prepare.sh`](https://github.com/esl/cimg-erlang/blob/master/tools/prepare.sh)).
+Optionally, you can set the `OPENSSL_VERSION` argument (e.g., `3.0.16`) to choose which OpenSSL version should be compiled for use on older systems.
 
 ## Trigger build using "Trigger pipeline" on CircleCI
 

--- a/compile.sh
+++ b/compile.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 docker build --progress=${PROGRESS:-auto} --build-arg BASE_IMAGE --build-arg OTP_VERSION \
+    --build-arg OPENSSL_VERSION=${OPENSSL_VERSION:-3.0.16} \
     -t cimg-erlang-builder -f Dockerfile-compile .
 BUILDER=`docker create cimg-erlang-builder`
 docker cp $BUILDER:builds .

--- a/tools/erlang_setup.sh
+++ b/tools/erlang_setup.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source /tools/utils.sh
+
+compile() {
+    ERLANG_DOWNLOAD_URL="https://github.com/erlang/otp/releases/download/OTP-${OTP_VERSION}/otp_src_${OTP_VERSION}.tar.gz"
+    mkdir /erlang-src
+    cd /erlang-src
+    curl -fSL -o erlang.tar.gz "$ERLANG_DOWNLOAD_URL"
+    tar -xzf erlang.tar.gz --strip-components=1
+
+    if needs_compiled_openssl; then
+        ./configure --with-ssl=/usr/local/ssl
+    else
+        ./configure
+    fi
+
+    make
+
+    mkdir -p /builds
+    tar -czf /builds/erlang-${TARGETARCH}.tar.gz /erlang-src
+}
+
+install() {
+    tar -xzf /builds/erlang-${TARGETARCH}.tar.gz -C /
+
+    cd /erlang-src
+    make install
+
+    cd
+    rm -rf /erlang-src
+}
+
+case ${1:-} in
+    compile)
+        compile
+        ;;
+    install)
+        install
+        ;;
+    *)
+        echo "Usage: $0 {compile|install}"
+        exit 1
+        ;;
+esac

--- a/tools/openssl_setup.sh
+++ b/tools/openssl_setup.sh
@@ -14,8 +14,10 @@ compile() {
         tar -xzf openssl.tar.gz --strip-components=1
 
         ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib
-        make -j"$(nproc)"
-        make install
+        make build_libs -j"$(nproc)"
+        make install_sw
+
+        rm -rf /usr/local/ssl/bin/
 
         mkdir -p /builds
         tar -czf /builds/openssl-${TARGETARCH}.tar.gz -C /usr/local/ssl .

--- a/tools/openssl_setup.sh
+++ b/tools/openssl_setup.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source /tools/utils.sh
+
+compile() {
+    if needs_compiled_openssl; then
+        echo "Compiling OpenSSL $OPENSSL_VERSION."
+        OPENSSL_DOWNLOAD_URL="https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz"
+        mkdir /openssl-src
+        cd /openssl-src
+
+        curl -fSL -o openssl.tar.gz "$OPENSSL_DOWNLOAD_URL"
+        tar -xzf openssl.tar.gz --strip-components=1
+
+        ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib
+        make -j"$(nproc)"
+        make install
+
+        mkdir -p /builds
+        tar -czf /builds/openssl-${TARGETARCH}.tar.gz -C /usr/local/ssl .
+    else
+        echo "System OpenSSL is sufficient — skipping build."
+    fi
+}
+
+install() {
+    if needs_compiled_openssl; then
+        echo "Extracting bundled OpenSSL."
+        mkdir /usr/local/ssl
+        tar -xzf /builds/openssl-${TARGETARCH}.tar.gz -C /usr/local/ssl
+    else
+        echo "No bundled OpenSSL found. Skipping setup."
+    fi
+}
+
+case ${1:-} in
+    compile)
+        compile
+        ;;
+    install)
+        install
+        ;;
+    *)
+        echo "Usage: $0 {compile|install}"
+        exit 1
+        ;;
+esac

--- a/tools/utils.sh
+++ b/tools/utils.sh
@@ -19,7 +19,7 @@ needs_compiled_openssl() {
     OS_VERSION=$(grep ^VERSION_ID= /etc/os-release | cut -d= -f2 | tr -d '"' | cut -d. -f1)
 
     if { [ "$OS_ID" = "ubuntu" ] && [ "$OS_VERSION" -lt 22 ]; } || \
-       { [ "$OS_ID" = "debian" ] && [ "$OS_VERSION" -lt 11 ]; } || \
+       { [ "$OS_ID" = "debian" ] && [ "$OS_VERSION" -lt 12 ]; } || \
        { [ "$OS_ID" = "rocky" ] && [ "$OS_VERSION" -lt 9 ]; } || \
        { [ "$OS_ID" = "almalinux" ] && [ "$OS_VERSION" -lt 9 ]; }; then
         return 0

--- a/tools/utils.sh
+++ b/tools/utils.sh
@@ -13,3 +13,17 @@ set_up_build() {
         IMAGE_TAG=${BASE_IMAGE_NAME}-${BASE_IMAGE_VERSION}-${OTP_VERSION}
     fi
 }
+
+needs_compiled_openssl() {
+    OS_ID=$(grep ^ID= /etc/os-release | cut -d= -f2 | tr -d '"')
+    OS_VERSION=$(grep ^VERSION_ID= /etc/os-release | cut -d= -f2 | tr -d '"' | cut -d. -f1)
+
+    if { [ "$OS_ID" = "ubuntu" ] && [ "$OS_VERSION" -lt 22 ]; } || \
+       { [ "$OS_ID" = "debian" ] && [ "$OS_VERSION" -lt 11 ]; } || \
+       { [ "$OS_ID" = "rocky" ] && [ "$OS_VERSION" -lt 9 ]; } || \
+       { [ "$OS_ID" = "almalinux" ] && [ "$OS_VERSION" -lt 9 ]; }; then
+        return 0
+    else
+        return 1
+    fi
+}


### PR DESCRIPTION
This PR adds support for compiling OpenSSL 3.x on systems where it is not available in official repositories.

To manage the added complexity of handling multiple system versions, some `RUN` commands in the Dockerfile were moved into separate scripts to improve readability.

Additionally, the `prepare.sh` script was updated to install the extra packages required when OpenSSL 3.x needs to be compiled during the build process.

Note that the compiled OpenSSL version is used specifically by Erlang and may differ from the system-wide OpenSSL version.